### PR TITLE
Add line_comments

### DIFF
--- a/languages/rst/config.toml
+++ b/languages/rst/config.toml
@@ -1,4 +1,4 @@
 name = "reST"
 grammar = "rst"
 path_suffixes = ["rst"]
-
+line_comments = [".. "]


### PR DESCRIPTION
This allows `cmd-/` to toggle the current line as a comment.

Single-line comments aren’t recommended in rST, because they share syntax with directives: https://stackoverflow.com/a/4783854/1427135 . But I still find them useful and I’d like to keep the shortcut working.

I tested this change with “Install Dev Extension” per https://zed.dev/docs/extensions/developing-extensions#developing-an-extension-locally .