### PR TITLE
Remove line_comments

### DIFF
--- a/languages/rst/config.toml
+++ b/languages/rst/config.toml
@@ -1,4 +1,4 @@
 name = "reST"
 grammar = "rst"
 path_suffixes = ["rst"]
-line_comments = [".. "]
+


### PR DESCRIPTION
Revert #1 / 646e6cf154f374051b797524fc01a0d38aa86e5d. After using this for a bit, I found it makes Zed treat any directive as a block comment. For example, if you type:

```
.. code-block:: python
```

...then press enter, you end up with:


```
.. code-block:: python
.. 
```

That's a bit annoying, I’d rather have an empty line to paste code into. Similarly, for other directives I'd want an empty line.