### PR TITLE
fix: esbonio v2.0.0 compatibility

### DIFF
--- a/src/rst.rs
+++ b/src/rst.rs
@@ -31,7 +31,7 @@ impl zed::Extension for RstExtension {
     ) -> Result<zed::Command> {
         Ok(zed::Command {
             command: self.language_server_binary_path(language_server_id, worktree)?,
-            args: vec![],
+            args: vec!["server".to_string()],
             env: Default::default(),
         })
     }


### PR DESCRIPTION
## Summary
- Pass the `server` subcommand to the `esbonio` CLI, as required by esbonio 2.0.0
- The `esbonio` command no longer starts the LSP server by default; `esbonio server` is now required

Fixes #11

## Test plan
- [ ] Install esbonio >= 2.0.0 (`pip install esbonio>=2.0.0`)
- [ ] Open an `.rst` file in Zed and verify the language server starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)